### PR TITLE
Modified required binaries and executable path for No Man's Sky

### DIFF
--- a/game-nomanssky/index.js
+++ b/game-nomanssky/index.js
@@ -15,9 +15,9 @@ function main(context) {
     queryPath: findGame,
     queryModPath: () => path.join('GAMEDATA', 'PCBANKS', 'MODS'),
     logo: 'gameart.png',
-    executable: () => 'NMS.exe',
+    executable: () => 'Binaries/NMS.exe',
     requiredFiles: [
-      'NMS.exe',
+      'Binaries/NMS.exe',
     ],
     details: {
       steamAppId: 275850,


### PR DESCRIPTION
Using just 'NMS.exe' doesn't allow you to select the No Man's Sky folder itself, forcing you to select the Binaries folder. If you select the Binaries folder, activating the extension fails since the mod search path always fails since "$root$/Binaries/GAMEDATA/PCBANKS/MODS" will never exist.