### PR TITLE
Fix Morrowind path

### DIFF
--- a/game-morrowind/index.js
+++ b/game-morrowind/index.js
@@ -10,9 +10,7 @@ function findGame() {
 
   let regKey = new Registry({
     hive: Registry.HKLM,
-    // Morrowind, being an old application, has its registry accesses
-    // redirected post Vista (?)
-    key: '\\Software\\Classes\\VirtualStore\\MACHINE\\SOFTWARE\\Wow6432Node\\bethesda softworks\\Morrowind',
+    key: '\\Software\\Wow6432Node\\bethesda softworks\\Morrowind',
   });
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Morrowind by default installs to "Program Files" or "Program Files (x86)" and will try to escalate privileges, so the registry key won't be redirected in 99% of cases.