### PR TITLE
Couple of minor corrections for different games

### DIFF
--- a/game-dragons-dogma/info.json
+++ b/game-dragons-dogma/info.json
@@ -1,6 +1,6 @@
 {
-  "name": "Game: Dragon's Dogma - Dark Arisen",
+  "name": "Game: Dragon's Dogma: Dark Arisen",
   "author": "Black Tree Gaming Ltd.",
   "version": "1.0.0",
-  "description": "Support for Dragon's Dogma - Dark Arisen"
+  "description": "Support for Dragon's Dogma: Dark Arisen"
 }

--- a/game-falloutnv/info.json
+++ b/game-falloutnv/info.json
@@ -1,6 +1,6 @@
 {
-  "name": "Game: FalloutNV",
+  "name": "Game: Fallout: New Vegas",
   "author": "Black Tree Gaming Ltd.",
   "version": "1.0.0",
-  "description": "Support for Fallout New Vegas"
+  "description": "Support for Fallout: New Vegas"
 }

--- a/game-skyrimse/info.json
+++ b/game-skyrimse/info.json
@@ -1,5 +1,5 @@
 {
-  "name": "Game: SkyrimSE",
+  "name": "Game: Skyrim: Special Edition",
   "author": "Black Tree Gaming Ltd.",
   "version": "1.0.0",
   "description": "Support for The Elder Scrolls V: Skyrim Special Edition"

--- a/game-skyrimvr/info.json
+++ b/game-skyrimvr/info.json
@@ -1,6 +1,6 @@
 {
-  "name": "Game: SkyrimSE",
+  "name": "Game: Skyrim VR",
   "author": "Black Tree Gaming Ltd.",
   "version": "1.0.0",
-  "description": "Support for The Elder Scrolls V: Skyrim Special Edition"
+  "description": "Support for The Elder Scrolls V: Skyrim VR"
 }

--- a/game-xcom2/index.js
+++ b/game-xcom2/index.js
@@ -3,7 +3,7 @@ const path = require('path');
 function main(context) {
   context.registerGame({
     id: 'xcom2',
-    name: 'X-COM 2',
+    name: 'XCOM 2',
     logo: 'gameart.png',
     mergeMods: true,
     queryModPath: () => path.join('XComGame', 'Mods'),

--- a/game-xcom2/info.json
+++ b/game-xcom2/info.json
@@ -1,6 +1,6 @@
 {
-  "name": "Game: X-Com 2",
+  "name": "Game: XCOM 2",
   "author": "Black Tree Gaming Ltd.",
   "version": "1.0.0",
-  "description": "Support for X-Com 2"
+  "description": "Support for XCOM 2"
 }


### PR DESCRIPTION
The name for the Skyrim VR extension wasn't changed when it was copied from the Skryim: Special edition extension. XCOM 2 was also incorrectly named as "X-Com 2," which has been fixed. Some extensions have also been given better names, like "Game: Skyrim: Special Edition" instead of "Game: SkryimSE."