### PR TITLE
Corrected Game Extension Naming

### DIFF
--- a/game-neverwinter-nights2/info.json
+++ b/game-neverwinter-nights2/info.json
@@ -1,6 +1,6 @@
 {
-  "name": "Game: Neverwinter Nights",
+  "name": "Game: Neverwinter Nights 2",
   "author": "Black Tree Gaming Ltd.",
   "version": "1.0.0",
-  "description": "Support for Neverwinter Nights"
+  "description": "Support for Neverwinter Nights 2"
 }

--- a/game-oni/info.json
+++ b/game-oni/info.json
@@ -1,5 +1,5 @@
 {
-  "name": "Oxygen Not Included",
+  "name": "Game: Oxygen Not Included",
   "author": "newman55",
   "version": "1.0.0",
   "description": "Support for Oxygen Not Included"


### PR DESCRIPTION
Changes:
- **Oxygen Not Included** Extension renamed to **Game: Oxygen Not Included** for consistency with other extensions.
- The Neverwinter Nights 2 Extension had the same name as Neverwinter Nights 1, resulting in a duplicated, non-functioning entry.