### PR TITLE
(Subnatica/Subnautica BZ) Ensure QMods folder exists when first managing the game

### DIFF
--- a/game-subnautica/index.js
+++ b/game-subnautica/index.js
@@ -13,16 +13,6 @@ class Subnautica {
     this.name = 'Subnautica';
     this.mergeMods = true;
     this.queryModPath = () => 'QMods';
-	  this.supportedTools = [{
-      id: 'qmods',
-      name: 'QModManager',
-      executable: () => 'QModManager.exe',
-      requiredFiles: [
-        'QModManager.exe',
-      ],
-      relative: true,
-      shell: true,
-    }];
     this.logo = 'gameart.jpg';
     this.executable = () => 'Subnautica.exe';
     this.requiredFiles = [
@@ -49,9 +39,9 @@ class Subnautica {
   }
   
   async setup(discovery) {
-    const qmodPath = path.join(discovery.path, 'BepInEx', 'patchers', 'QModManager', 'QModManager.exe');
+    const qmodPath = path.join(discovery.path, 'BepInEx', 'plugins', 'QModManager', 'QModInstaller.dll');
   
-    // show need-QModManager dialogue
+    // show need-QModManager dialogue and create the mods folder, if it's not already there.
     var context = this.context;
     return fs.statAsync(qmodPath).catch(() => new Promise((resolve, reject) => {
       context.api.store.dispatch(
@@ -65,7 +55,7 @@ class Subnautica {
           ]
         )
       );
-    }));
+    })).then(() => fs.ensureDirWritableAsync(path.join(discovery.path, 'QMods')));
   }
 }
 

--- a/game-subnautica/info.json
+++ b/game-subnautica/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Game: Subnautica",
   "author": "Chloe S. & AlexejheroYTB",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Support for Subnautica"
 }

--- a/game-subnauticabelowzero/index.js
+++ b/game-subnauticabelowzero/index.js
@@ -13,17 +13,6 @@ class SubnauticaBelowZero {
     this.name = 'Subnautica: Below Zero';
     this.mergeMods = true;
     this.queryModPath = () => 'QMods';
-    this.supportedTools = [{
-      id: 'qmods',
-      name: 'QModManager',
-      executable: () => 'QModManager.exe',
-      requiredFiles: [
-        'QModManager.exe',
-      ],
-      relative: true,
-      shell: true,
-      }
-    ];
     this.logo = 'gameart.jpg';
     this.executable = () => 'SubnauticaZero.exe';
     this.requiredFiles = [
@@ -62,7 +51,7 @@ class SubnauticaBelowZero {
     }
 
     // skip if QModManager found
-    const qmodPath = path.join(discovery.path, 'BepInEx', 'patchers', 'QModManager', 'QModManager.exe')
+    const qmodPath = path.join(discovery.path, 'BepInEx', 'plugins', 'QModManager', 'QModInstaller.dll');
   
     // show need-QModManager dialogue
     var context = this.context;
@@ -78,7 +67,7 @@ class SubnauticaBelowZero {
           ]
         )
       );
-    }));
+    })).then(() => fs.ensureDirWritableAsync(path.join(discovery.path, 'QMods')));
   }
 }
 

--- a/game-subnauticabelowzero/info.json
+++ b/game-subnauticabelowzero/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Game: Subnautica Below Zero",
   "author": "Chloe S. & AlexejheroYTB",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Support for Subnautica: Below Zero"
 }


### PR DESCRIPTION
Check for QModInstaller.dll instead of QModManager.exe for long-term compatibility.
Removed QMM shortcut from the dashboard
Check QMods folder exists and create it if it doesn't. 
