### PR TITLE
(Sekiro) Fix casing of Sekiro's gameExec

### DIFF
--- a/game-sekiro/index.js
+++ b/game-sekiro/index.js
@@ -67,7 +67,7 @@ function testLooseMod(files, gameId) {
 }
 
 function main(context) {
-  const gameExec = 'Sekiro.exe';
+  const gameExec = 'sekiro.exe';
   _API = context.api;
   context.registerGame({
     id: GAME_ID,


### PR DESCRIPTION
File as [provided by Steam](https://steamdb.info/depot/814381/) has all–lowercase name, which causes Sekiro to not be detected correctly when installed on case–sensitive filesystems *cough* ext4 *cough* Linux *cough*.

This change is not expected to affect anyone using case–insensitive filesystem at all, like NTFS in default configuration.