### PR TITLE
Allow whitespace, hyphens, and underscores in Mod Names

### DIFF
--- a/game-bladeandsorcery/util.js
+++ b/game-bladeandsorcery/util.js
@@ -46,8 +46,8 @@ async function getModName(manifestFilePath, element, ext) {
     return Promise.reject(new util.DataInvalid(`"${element}" JSON element is missing`));
   }
 
-  // remove all characters except for characters and numbers.
-  modName = modName.replace(/[^a-zA-Z0-9]+/g, '');
+  // remove all characters except for letters, numbers, whitespace, hyphens, and underscores.
+  modName = modName.replace(/[^\w\d\s-_]+/g, '');
 
   return ext !== undefined
     ? Promise.resolve(path.basename(modName, ext))


### PR DESCRIPTION
Fixes the sanitisation method to allow whitespace, hyphens, and underscores in manifest Mod Names. 

Currently required to resolve issues with mods requiring specific directory names as Vortex is currently stripping out spaces.