### PR TITLE
Ignore conflicts with `PersistantSubgraphInfoAndOffsetData.txt`

### DIFF
--- a/game-fallout4/index.js
+++ b/game-fallout4/index.js
@@ -3,6 +3,13 @@ const path = require('path');
 const { util } = require('vortex-api');
 const winapi = require('winapi-bindings');
 
+/* 
+Ignore the Meshes\AnimTextData\AnimationOffsets\PersistantSubgraphInfoAndOffsetData.txt file as a conflict. 
+It's present in a lot of weapon mods but doesn't matter if it's overwritten. 
+This issue is compounded by users extracting all their BA2s. 
+*/
+const IGNORED_FILES = ['PersistantSubgraphInfoAndOffsetData.txt', 'persistantsubgraphinfoandoffsetdata.txt'];
+
 const MS_ID = 'BethesdaSoftworks.Fallout4-PC';
 function findGame() {
   try {
@@ -98,6 +105,7 @@ function main(context) {
     },
     details: {
       steamAppId: 377160,
+      ignoreConflicts: 
     }
   });
 

--- a/game-fallout4/index.js
+++ b/game-fallout4/index.js
@@ -8,7 +8,8 @@ Ignore the Meshes\AnimTextData\AnimationOffsets\PersistantSubgraphInfoAndOffsetD
 It's present in a lot of weapon mods but doesn't matter if it's overwritten. 
 This issue is compounded by users extracting all their BA2s. 
 */
-const IGNORED_FILES = ['PersistantSubgraphInfoAndOffsetData.txt', 'persistantsubgraphinfoandoffsetdata.txt'];
+const PersistantSubgraphInfoAndOffsetData = path.join('Meshes', 'AnimTextData', 'AnimationOffsets', 'PersistantSubgraphInfoAndOffsetData.txt');
+const IGNORED_FILES = [PersistantSubgraphInfoAndOffsetData, PersistantSubgraphInfoAndOffsetData.toLowerCase()];
 
 const MS_ID = 'BethesdaSoftworks.Fallout4-PC';
 function findGame() {

--- a/game-fallout4/index.js
+++ b/game-fallout4/index.js
@@ -105,7 +105,7 @@ function main(context) {
     },
     details: {
       steamAppId: 377160,
-      ignoreConflicts: 
+      ignoreConflicts: IGNORED_FILES
     }
   });
 

--- a/game-fallout4/index.js
+++ b/game-fallout4/index.js
@@ -8,8 +8,7 @@ Ignore the Meshes\AnimTextData\AnimationOffsets\PersistantSubgraphInfoAndOffsetD
 It's present in a lot of weapon mods but doesn't matter if it's overwritten. 
 This issue is compounded by users extracting all their BA2s. 
 */
-const PersistantSubgraphInfoAndOffsetData = path.join('Meshes', 'AnimTextData', 'AnimationOffsets', 'PersistantSubgraphInfoAndOffsetData.txt');
-const IGNORED_FILES = [PersistantSubgraphInfoAndOffsetData, PersistantSubgraphInfoAndOffsetData.toLowerCase()];
+const IGNORED_FILES = [ path.join('**', 'PersistantSubgraphInfoAndOffsetData.txt'); ];
 
 const MS_ID = 'BethesdaSoftworks.Fallout4-PC';
 function findGame() {

--- a/game-fallout4/info.json
+++ b/game-fallout4/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Game: Fallout 4",
   "author": "Black Tree Gaming Ltd.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Support for Fallout 4"
 }

--- a/game-fallout4vr/index.js
+++ b/game-fallout4vr/index.js
@@ -9,7 +9,8 @@ Ignore the Meshes\AnimTextData\AnimationOffsets\PersistantSubgraphInfoAndOffsetD
 It's present in a lot of weapon mods but doesn't matter if it's overwritten. 
 This issue is compounded by users extracting all their BA2s. 
 */
-const IGNORED_FILES = ['PersistantSubgraphInfoAndOffsetData.txt', 'persistantsubgraphinfoandoffsetdata.txt'];
+const PersistantSubgraphInfoAndOffsetData = path.join('Meshes', 'AnimTextData', 'AnimationOffsets', 'PersistantSubgraphInfoAndOffsetData.txt');
+const IGNORED_FILES = [PersistantSubgraphInfoAndOffsetData, PersistantSubgraphInfoAndOffsetData.toLowerCase()];
 
 function findGame() {
   try {

--- a/game-fallout4vr/index.js
+++ b/game-fallout4vr/index.js
@@ -9,8 +9,7 @@ Ignore the Meshes\AnimTextData\AnimationOffsets\PersistantSubgraphInfoAndOffsetD
 It's present in a lot of weapon mods but doesn't matter if it's overwritten. 
 This issue is compounded by users extracting all their BA2s. 
 */
-const PersistantSubgraphInfoAndOffsetData = path.join('Meshes', 'AnimTextData', 'AnimationOffsets', 'PersistantSubgraphInfoAndOffsetData.txt');
-const IGNORED_FILES = [PersistantSubgraphInfoAndOffsetData, PersistantSubgraphInfoAndOffsetData.toLowerCase()];
+const IGNORED_FILES = [ path.join('**', 'PersistantSubgraphInfoAndOffsetData.txt'); ];
 
 function findGame() {
   try {

--- a/game-fallout4vr/index.js
+++ b/game-fallout4vr/index.js
@@ -4,6 +4,13 @@ const {getFileVersion} = require('exe-version');
 const { util } = require('vortex-api');
 const winapi = require('winapi-bindings');
 
+/* 
+Ignore the Meshes\AnimTextData\AnimationOffsets\PersistantSubgraphInfoAndOffsetData.txt file as a conflict. 
+It's present in a lot of weapon mods but doesn't matter if it's overwritten. 
+This issue is compounded by users extracting all their BA2s. 
+*/
+const IGNORED_FILES = ['PersistantSubgraphInfoAndOffsetData.txt', 'persistantsubgraphinfoandoffsetdata.txt'];
+
 function findGame() {
   try {
     const instPath = winapi.RegGetValue(
@@ -68,6 +75,7 @@ function main(context) {
     details: {
       steamAppId: 611660,
       compatibleDownloads: ['fallout4'],
+      ignoreConflicts: IGNORED_FILES
     }
   });
 

--- a/game-fallout4vr/info.json
+++ b/game-fallout4vr/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Game: Fallout 4 VR",
   "author": "Black Tree Gaming Ltd.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Support for the VR variant of Fallout 4"
 }


### PR DESCRIPTION
Ignore the `Meshes\AnimTextData\AnimationOffsets\PersistantSubgraphInfoAndOffsetData.txt` file as a conflict. 
It's present in a lot of weapon mods but doesn't matter if it's overwritten. 
This issue is compounded by users extracting all their BA2s.