### PR TITLE
[XCOM2]Fixed an issue in detecting which mods are currently enabled.

### DIFF
--- a/game-xcom2/index.js
+++ b/game-xcom2/index.js
@@ -272,10 +272,10 @@ async function deserializeLoadOrder(api, gameId) {
   try {
     const file = await fs.readFileAsync(optionsIni, 'utf8');
     const arr = file.split('\n');
-    const active = arr.filter(line => line.startsWith('ActiveMods='));
-    const names = active.map(mod => mod.replace('ActiveMods=', '').replace(/"/g,''));
+    const active = arr.filter(line => line.startsWith('ActiveMods=')).map(m => m.replace('ActiveMods=', ''));
+    const names = active.map(mod => mod.replace(/"/g,''));
     // Only shown enabled mods that actually have a folder.
-    enabledMods = names.filter(name => folders.includes(name));
+    enabledMods = names.filter(name => folders.includes(name) || workshopMods.includes(name));
   }
   catch(err) {
     if (err.code === 'ENOENT') log('info', `${MOD_OPTIONS} does not exist for ${gameId}`);

--- a/game-xcom2/index.js
+++ b/game-xcom2/index.js
@@ -114,7 +114,8 @@ function main(context) {
     details: {
       steamAppId: STEAMAPP_ID,
       gogAppId: GOGAPP_ID,
-      nexusPageId: 'xcom2'
+      nexusPageId: 'xcom2',
+      compatibleDownloads: ['xcom2']
     },
   });
 

--- a/game-xcom2/info.json
+++ b/game-xcom2/info.json
@@ -1,6 +1,6 @@
 {
     "name": "Game: XCOM 2",
     "author": "Black Tree Gaming Ltd.",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Support for XCOM 2 and XCOM 2: War of the Chosen"
   }


### PR DESCRIPTION
Now check both Vortex and Steam mods when showing the load order page.
Corrected parsing error on mod names from the `\r` character.