### PR TITLE
Epic Games support for Skyrim SE

### DIFF
--- a/game-skyrimse/index.js
+++ b/game-skyrimse/index.js
@@ -7,6 +7,8 @@ const winapi = require('winapi-bindings');
 const GAME_ID = 'skyrimse';
 const GOG_ID = '1711230643';
 const MS_ID = 'BethesdaSoftworks.SkyrimSE-PC';
+const EPIC_ID = 'ac82db5035584c7f8a2c548d98c86b2c';
+
 async function findGame() {
   try {
     return await util.steam.findByName('The Elder Scrolls V: Skyrim Special Edition');
@@ -20,6 +22,11 @@ async function findGame() {
   }
   try {
     return await util.GameStoreHelper.findByAppId([GOG_ID], 'gog');
+  } catch (err) {
+    // nop
+  }
+  try {
+    return await util.GameStoreHelper.findByAppId([EPIC_ID], 'epic');
   } catch (err) {
     // nop
   }


### PR DESCRIPTION
Vortex will now be able to detect Epic Games versions of Skyrim SE.

The Epic Games version does not appear to need to be launched via the EGS Store, so the requiresLauncher function has not been changed. 