### PR TITLE
Fix: (Master Chief Collection [Steam]) Launch without AntiCheat

### DIFF
--- a/game-masterchiefcollection/index.js
+++ b/game-masterchiefcollection/index.js
@@ -171,7 +171,7 @@ class MasterChiefCollectionGame {
         launcher: 'steam',
         addInfo: {
           appId: STEAM_ID,
-          parameters: ['option1'],
+          parameters: ['option2'],
           launchType: 'gamestore',
         }
       });


### PR DESCRIPTION
Simple fix to launch Halo without anticheat with the Steam installation.