### PR TITLE
Blade and Sorcery fix for 1.0.0.0

### DIFF
--- a/game-bladeandsorcery/index.js
+++ b/game-bladeandsorcery/index.js
@@ -112,9 +112,9 @@ async function getOfficialModType(api, discovery = undefined) {
   } catch (err) {
     return missingGameJsonError(api, err);
   }
-  const segments = gameVersion.split('.');
-  const ver = segments[0] === '0' ? segments.slice(1).join('.') : gameVersion;
-  const modType = semver.gte(semver.coerce(ver), semver.coerce('8.4'))
+  //const segments = gameVersion.split('.');
+  //const ver = segments[0] === '0' ? segments.slice(1).join('.') : gameVersion;
+  const modType = semver.gte(semver.coerce(gameVersion), semver.coerce('0.8.4'))
     ? 'bas-official-modtype' : 'bas-legacy-modtype';
   return Promise.resolve(modType);
 }


### PR DESCRIPTION
The extension incorrectly detects the type of mod, legacy or official. The previous versions were formatted like `0.12.0.0` for update 12. When the full release came out, the version is now formatted like `1.0.0.0`, which causes the extension to detect a mod as a legacy mod, rather than an official mod.

This is one of my first PRs, so let me know if I messed anything up.