### PR TITLE
Gamebryo VR - adding nexus page ids to consolidate gamebryo extension pattern

### DIFF
--- a/game-fallout4vr/index.js
+++ b/game-fallout4vr/index.js
@@ -75,7 +75,8 @@ function main(context) {
     details: {
       steamAppId: 611660,
       compatibleDownloads: ['fallout4'],
-      ignoreConflicts: IGNORED_FILES
+      ignoreConflicts: IGNORED_FILES,
+      nexusPageId: 'fallout4',
     }
   });
 

--- a/game-fallout4vr/info.json
+++ b/game-fallout4vr/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Game: Fallout 4 VR",
   "author": "Black Tree Gaming Ltd.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Support for the VR variant of Fallout 4"
 }

--- a/game-skyrimvr/index.js
+++ b/game-skyrimvr/index.js
@@ -161,6 +161,7 @@ function main(context) {
       steamAppId: 611670,
       compatibleDownloads: ['skyrimse'],
       supportsESL: () => isESLSupported(context.api),
+      nexusPageId: 'skyrimspecialedition',
     }
   });
 

--- a/game-skyrimvr/info.json
+++ b/game-skyrimvr/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Game: Skyrim VR",
   "author": "Black Tree Gaming Ltd.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Support for The Elder Scrolls V: Skyrim VR"
 }


### PR DESCRIPTION
The gameId -> NXM or vice-versa conversion function will no longer be needed once the nxm links match the game domain; this is just preparing the game extensions themselves for the removal of the conversion function.

All other Gamebryo extensions are already following this pattern.