### PR TITLE
W3: fixed menu mod re-generation as part of collections

### DIFF
--- a/game-witcher3/info.json
+++ b/game-witcher3/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Game: The Witcher 3",
   "author": "Black Tree Gaming Ltd.",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "description": "Support for The Witcher 3"
 }

--- a/game-witcher3/menumod.js
+++ b/game-witcher3/menumod.js
@@ -158,7 +158,8 @@ function convertFilePath(filePath, installPath) {
     log('error', 'unexpected menu mod filepath', filePath);
     return filePath;
   }
-  const relPath = segments.slice(idx + 1).join(path.sep);
+  // We slice off everything up to the GAME_ID and the 'mods' folder.
+  const relPath = segments.slice(idx + 2).join(path.sep);
   return path.join(installPath, relPath);
 }
 


### PR DESCRIPTION
This would exhibit itself as an "unhandled exception" in the will-deploy handler on the user's end. (curator would not be able to reproduce it)