### PR TITLE
Daggerfall Unity: Fix for .dfmod files not being in a 'mods' subfolder

### DIFF
--- a/game-daggerfallunity/index.js
+++ b/game-daggerfallunity/index.js
@@ -75,11 +75,23 @@ function install(files, destinationPath) {
   filtered.forEach(file => {
     if (dfmods.indexOf(path.basename(file)) !== -1) {
       if (path.dirname(file).toLowerCase().indexOf('windows') !== -1) {
+        let targetPath;
+
+        //Check if the mod targets the DFU mods folder
+        if(path.dirname(file).toLowerCase().indexOf('mods') !== -1)
+        {
+          targetPath = path.basename(file);
+        }
+        else //mod is in root of the .zip, which is wrong
+        {
+          targetPath = path.join('Mods', path.basename(file));
+        }
+        
         // This is the dfmod we want to install.
         result.instructions.push({
           type: 'copy',
           source: file,
-          destination: path.basename(file),
+          destination: targetPath,
         });
       }
     } else {

--- a/game-daggerfallunity/info.json
+++ b/game-daggerfallunity/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Game: Daggerfall Unity",
-  "author": "Black Tree Gaming Ltd.",
-  "version": "1.0.1",
+  "author": "AncientGrief",
+  "version": "1.0.2",
   "description": "Support for Daggerfall Unity"
 }

--- a/game-daggerfallunity/info.json
+++ b/game-daggerfallunity/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Game: Daggerfall Unity",
-  "author": "AncientGrief",
+  "author": "Black Tree Gaming Ltd. & AncientGrief",
   "version": "1.0.2",
   "description": "Support for Daggerfall Unity"
 }


### PR DESCRIPTION
This is a fix for Daggerfall Unity. A check was added, to see if .dfmod files are inside a `mods` sub-folder. If not, the file path gets corrected, since DFU mod files belong in the `StreamingAssets/Mods` subfolder and not in `StreamingAssets`.

Edit:
A lot of mod devs do not follow the convention, becasue they do not know better or don't care about Vortex compatibility.

Some Examples of popular mods that do it wrong:
https://www.nexusmods.com/daggerfallunity/mods/189
https://www.nexusmods.com/daggerfallunity/mods/144
https://www.nexusmods.com/daggerfallunity/mods/18

Edit 2:
After looking further into the existing code, this whole thing seems to use some "legacy" logic, based off of the beginning of DFU modding I think. A lot of mod devs do not ship all platforms in one .zip anymore (me included). Thus the check for platforms is outdated and sometimes even wrong.

I will try to rework the script further to support "legacy" mods (that still work) and mods that don't use a `mods` subfolder at all or some other weird custom named folders.