### PR TITLE
BG3/W3 fixed incorrect onStateChange event handlers registration

### DIFF
--- a/game-baldursgate3/index.js
+++ b/game-baldursgate3/index.js
@@ -3560,17 +3560,15 @@ function main(context) {
   context.once(() => {
     context.api.onStateChange(
       ["session", "base", "toolsRunning"],
-      async (prev, current) => {
+      (prev, current) => {
         const gameMode = import_vortex_api10.selectors.activeGameId(context.api.getState());
         if (gameMode === GAME_ID && Object.keys(current).length === 0) {
-          try {
-            await readStoredLO(context.api);
-          } catch (err) {
+          readStoredLO(context.api).catch((err) => {
             context.api.showErrorNotification("Failed to read load order", err, {
               message: "Please run the game before you start modding",
               allowReport: false
             });
-          }
+          });
         }
       }
     );

--- a/game-baldursgate3/index.tsx
+++ b/game-baldursgate3/index.tsx
@@ -339,19 +339,17 @@ function main(context: types.IExtensionContext) {
 
   context.once(() => {
     context.api.onStateChange(['session', 'base', 'toolsRunning'],
-      async (prev: any, current: any) => {
+      (prev: any, current: any) => {
         // when a tool exits, re-read the load order from disk as it may have been
         // changed
         const gameMode = selectors.activeGameId(context.api.getState());
         if ((gameMode === GAME_ID) && (Object.keys(current).length === 0)) {
-          try {
-            await readStoredLO(context.api);
-          } catch (err) {
+          readStoredLO(context.api).catch(err => {
             context.api.showErrorNotification('Failed to read load order', err, {
               message: 'Please run the game before you start modding',
               allowReport: false,
             });
-          }
+          });
         }
       });
 

--- a/game-baldursgate3/info.json
+++ b/game-baldursgate3/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Game: Baldur's Gate 3",
   "author": "Nexus Mods",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Support for Baldur's Gate 3"
 }

--- a/game-witcher3/eventHandlers.ts
+++ b/game-witcher3/eventHandlers.ts
@@ -167,7 +167,7 @@ export const onProfileWillChange = (api: types.IExtensionApi) => {
 }
 
 export const onSettingsChange = (api: types.IExtensionApi, priorityManager: () => PriorityManager) => {
-  return async (prev: string, current: any) => {
+  return (prev: string, current: any) => {
     const state = api.getState();
     const activeProfile = selectors.activeProfile(state);
     if (activeProfile?.gameId !== GAME_ID || priorityManager === undefined) {
@@ -176,9 +176,6 @@ export const onSettingsChange = (api: types.IExtensionApi, priorityManager: () =
 
     const priorityType = util.getSafe(state, getPriorityTypeBranch(), 'prefix-based');
     priorityManager().priorityType = priorityType;
-    api.events.on('purge-mods', () => {
-      IniStructure.getInstance().revertLOFile();
-    });
   }
 }
 

--- a/game-witcher3/index.js
+++ b/game-witcher3/index.js
@@ -3469,7 +3469,7 @@ var onProfileWillChange = (api) => {
   };
 };
 var onSettingsChange = (api, priorityManager2) => {
-  return async (prev, current) => {
+  return (prev, current) => {
     const state = api.getState();
     const activeProfile = import_vortex_api20.selectors.activeProfile(state);
     if (activeProfile?.gameId !== GAME_ID || priorityManager2 === void 0) {
@@ -3477,9 +3477,6 @@ var onSettingsChange = (api, priorityManager2) => {
     }
     const priorityType = import_vortex_api20.util.getSafe(state, getPriorityTypeBranch(), "prefix-based");
     priorityManager2().priorityType = priorityType;
-    api.events.on("purge-mods", () => {
-      IniStructure.getInstance().revertLOFile();
-    });
   };
 };
 function getScriptMergerTool(api) {

--- a/game-witcher3/info.json
+++ b/game-witcher3/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Game: The Witcher 3",
   "author": "Black Tree Gaming Ltd.",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Support for The Witcher 3"
 }


### PR DESCRIPTION
onStateChange can only support synchronous handlers. The error would get reported on startup - not sure why this wasn't obvious in previous versions, possibly due to the consolidation work.